### PR TITLE
Throw a ConnectionException if the connection ends

### DIFF
--- a/src/React/Stomp/Factory.php
+++ b/src/React/Stomp/Factory.php
@@ -43,6 +43,10 @@ class Factory
             $input->emit('error', array($e));
         });
 
+        $conn->on('end', function () {
+            throw new ConnectionException('Connection has been lost');
+        });
+
         return new Client($this->loop, $input, $output, $options);
     }
 


### PR DESCRIPTION
This is a fix for #24

I think we should move the `stream_socket_client` call when `React\Stomp\Client::connect` is called. We could provide automatic reconnection that way.