### PR TITLE
Capture and emit input end event

### DIFF
--- a/src/React/Stomp/Client.php
+++ b/src/React/Stomp/Client.php
@@ -49,7 +49,7 @@ class Client extends EventEmitter
         $this->input = $input;
         $this->input->on('frame', array($this, 'handleFrameEvent'));
         $this->input->on('error', array($this, 'handleErrorEvent'));
-        $this->input->on('end', array($this, 'handleEndEvent'));
+        $this->input->on('close', array($this, 'handleCloseEvent'));
         $this->output = $output;
 
         $this->options = $this->sanatizeOptions($options);
@@ -82,7 +82,6 @@ class Client extends EventEmitter
             $this->options['login'],
             $this->options['passcode']
         );
-
         $this->output->sendFrame($frame);
 
         return $this->connectPromise = $deferred->promise()->then(function () use ($client) {
@@ -182,13 +181,13 @@ class Client extends EventEmitter
         $this->emit('error', array($e));
     }
 
-    public function handleEndEvent()
+    public function handleCloseEvent()
     {
         $this->connectDeferred = null;
         $this->connectPromise = null;
         $this->connectionStatus = 'not-connected';
 
-        $this->emit('end');
+        $this->emit('close');
     }
 
     public function processFrame(Frame $frame)

--- a/src/React/Stomp/Client.php
+++ b/src/React/Stomp/Client.php
@@ -49,6 +49,7 @@ class Client extends EventEmitter
         $this->input = $input;
         $this->input->on('frame', array($this, 'handleFrameEvent'));
         $this->input->on('error', array($this, 'handleErrorEvent'));
+        $this->input->on('end', array($this, 'handleEndEvent'));
         $this->output = $output;
 
         $this->options = $this->sanatizeOptions($options);
@@ -81,6 +82,7 @@ class Client extends EventEmitter
             $this->options['login'],
             $this->options['passcode']
         );
+
         $this->output->sendFrame($frame);
 
         return $this->connectPromise = $deferred->promise()->then(function () use ($client) {
@@ -178,6 +180,15 @@ class Client extends EventEmitter
     public function handleErrorEvent(\Exception $e)
     {
         $this->emit('error', array($e));
+    }
+
+    public function handleEndEvent()
+    {
+        $this->connectDeferred = null;
+        $this->connectPromise = null;
+        $this->connectionStatus = 'not-connected';
+
+        $this->emit('end');
     }
 
     public function processFrame(Frame $frame)

--- a/src/React/Stomp/Factory.php
+++ b/src/React/Stomp/Factory.php
@@ -42,6 +42,9 @@ class Factory
         $conn->on('error', function ($e) use ($input) {
             $input->emit('error', array($e));
         });
+        $conn->on('end', function () use ($input) {
+            $input->emit('end');
+        });
 
         return new Client($this->loop, $input, $output, $options);
     }

--- a/src/React/Stomp/Factory.php
+++ b/src/React/Stomp/Factory.php
@@ -42,8 +42,8 @@ class Factory
         $conn->on('error', function ($e) use ($input) {
             $input->emit('error', array($e));
         });
-        $conn->on('end', function () use ($input) {
-            $input->emit('end');
+        $conn->on('close', function () use ($input) {
+            $input->emit('close');
         });
 
         return new Client($this->loop, $input, $output, $options);

--- a/tests/React/Tests/Stomp/ClientTest.php
+++ b/tests/React/Tests/Stomp/ClientTest.php
@@ -672,15 +672,15 @@ class ClientTest extends TestCase
     }
 
     /** @test */
-    public function inputEndShouldResultInClientEnd()
+    public function inputCloseShouldResultInClientClose()
     {
         $input = $this->createInputStreamMock();
         $output = $this->getMock('React\Stomp\Io\OutputStreamInterface');
 
         $client = $this->getConnectedClient($input, $output);
-        $client->on('end', $this->expectCallableOnce());
+        $client->on('close', $this->expectCallableOnce());
 
-        $input->emit('end');
+        $input->emit('close');
     }
 
     private function getConnectedClient(InputStreamInterface $input, OutputStreamInterface $output)

--- a/tests/React/Tests/Stomp/ClientTest.php
+++ b/tests/React/Tests/Stomp/ClientTest.php
@@ -671,6 +671,18 @@ class ClientTest extends TestCase
         $input->emit('error', array($e));
     }
 
+    /** @test */
+    public function inputEndShouldResultInClientEnd()
+    {
+        $input = $this->createInputStreamMock();
+        $output = $this->getMock('React\Stomp\Io\OutputStreamInterface');
+
+        $client = $this->getConnectedClient($input, $output);
+        $client->on('end', $this->expectCallableOnce());
+
+        $input->emit('end');
+    }
+
     private function getConnectedClient(InputStreamInterface $input, OutputStreamInterface $output)
     {
         $client = new Client($this->createLoopMockWithConnectionTimer(), $input, $output, array('vhost' => 'localhost'));


### PR DESCRIPTION
This is another PR for reactphp/stomp#24.  It forwards the end event through the InputStream class and through the Client, similar to how errors are handled.

I need to handle server-side restarts, and I can't detect a disconnection without this fix.

Thank you!
## 

Jason
